### PR TITLE
Support AWS SDK overrides.

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -486,7 +486,10 @@ class Deb::S3::CLI < Thor
     access_key_id     = options[:access_key_id]
     secret_access_key = options[:secret_access_key]
 
-    if access_key_id.nil? && secret_access_key.nil?
+    if access_key_id.nil? &&
+       secret_access_key.nil? &&
+       ENV['AWS_ACCESS_KEY_ID'].nil? &&
+       ENV['AWS_SECRET_ACCESS_KEY'].nil?
       AWS::Core::CredentialProviders::EC2Provider.new
     else
       static_credentials = {}

--- a/lib/deb/s3/release.rb
+++ b/lib/deb/s3/release.rb
@@ -99,6 +99,16 @@ class Deb::S3::Release
     # sign the file, if necessary
     if Deb::S3::Utils.signing_key
       key_param = Deb::S3::Utils.signing_key != "" ? "--default-key=#{Deb::S3::Utils.signing_key}" : ""
+      if system("gpg -a #{key_param} #{Deb::S3::Utils.gpg_options} -s --clearsign #{release_tmp.path}")
+        local_file = release_tmp.path+".asc"
+        remote_file = "dists/#{@codename}/InRelease"
+        yield remote_file if block_given?
+        raise "Unable to locate InRelease file" unless File.exists?(local_file)
+        s3_store(local_file, remote_file, 'application/pgp-signature; charset=us-ascii', self.cache_control)
+        File.unlink(local_file)
+      else
+        raise "Signing the InRelease file failed."
+      end
       if system("gpg -a #{key_param} #{Deb::S3::Utils.gpg_options} -b #{release_tmp.path}")
         local_file = release_tmp.path+".asc"
         remote_file = self.filename+".gpg"


### PR DESCRIPTION
- make sure when AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are set
  the default credential is used instead of the EC2 provider (this used
  EC2 instance profiles)
- upgraded the AWS SDK gem
