### PR TITLE
Always generate InRelease file by default

### DIFF
--- a/lib/deb/s3/release.rb
+++ b/lib/deb/s3/release.rb
@@ -103,6 +103,16 @@ class Deb::S3::Release
     # sign the file, if necessary
     if Deb::S3::Utils.signing_key
       key_param = Deb::S3::Utils.signing_key != "" ? "--default-key=#{Deb::S3::Utils.signing_key}" : ""
+      if system("gpg -a #{key_param} #{Deb::S3::Utils.gpg_options} -s --clearsign #{release_tmp.path}")
+        local_file = release_tmp.path+".asc"
+        remote_file = "dists/#{@codename}/InRelease"
+        yield remote_file if block_given?
+        raise "Unable to locate InRelease file" unless File.exists?(local_file)
+        s3_store(local_file, remote_file, 'application/pgp-signature; charset=us-ascii', self.cache_control)
+        File.unlink(local_file)
+      else
+        raise "Signing the InRelease file failed."
+      end
       if system("gpg -a #{key_param} #{Deb::S3::Utils.gpg_options} -b #{release_tmp.path}")
         local_file = release_tmp.path+".asc"
         remote_file = self.filename+".gpg"


### PR DESCRIPTION
Copied this change from upstream, which should fix an issue for Ubuntu Bionic where the apt server couldn't be read because no InRelease file was generated.

It looks like some of the changes were already in place in our branch.

Here is the original pull request that I copied from, for reference.
https://github.com/krobertson/deb-s3/commit/7a73571bc64685c9bb6721c633a0bb0611958026